### PR TITLE
A fix for crashing problem

### DIFF
--- a/CardboardSDK/CBDViewController.mm
+++ b/CardboardSDK/CBDViewController.mm
@@ -273,6 +273,11 @@
     _headTracker->setNeckModelEnabled(neckModelEnabled);
 }
 
+- (void)setVrModeEnabled:(BOOL)vrModeEnabled {
+    _projectionChanged = YES;
+    _vrModeEnabled = vrModeEnabled;
+}
+
 - (void)triggerPressed:(NSNotification *)notification
 {
     if ([self.stereoRendererDelegate respondsToSelector:@selector(triggerPressed)])


### PR DESCRIPTION
If the vrModeEnabled is initially set to NO, and then switching it to YES will cause a crash, this commit just added a setter method for vrModeEnabled and problem solved.
