### PR TITLE
Exposing head orientation

### DIFF
--- a/CardboardSDK/CBDViewController.h
+++ b/CardboardSDK/CBDViewController.h
@@ -57,4 +57,11 @@ typedef NS_ENUM(NSInteger, CBDEyeType)
 
 - (void)getFrameParameters:(float *)frameParemeters zNear:(float)zNear zFar:(float)zFar;
 
+// extension to allow panning in mono mode
+@property (nonatomic) double offsetPan;
+@property (nonatomic) double offsetTilt;
+
+// return pitch, yaw, roll
+- (GLKVector3)eulerAngles;
+
 @end


### PR DESCRIPTION
This change does two things to expose the head orientation parameters from the CBDViewController. First, it adds the **eulerAngles**() method to export results from the **headTransform.eulerAngles**() method. This makes it more convenient to pass orientation tracking information to Objective-C clients. 
Second, this change adds offsetPan and offsetTilt properties, which are used to offset the view direction when **vrModeEnabled** is off. This makes it much easier for clients to add manual pan and tilt adjustment for devices that are not in a cardboard viewer.
